### PR TITLE
Build wheels against ABI3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "ruff_api"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.27.1"
+pyo3 = {version="0.27.1", features=["extension-module", "abi3-py39"]}
 glob = "0.3.2"
 ruff = { git = "https://github.com/astral-sh/ruff.git", tag = "0.14.3" }
 ruff_formatter = { git = "https://github.com/astral-sh/ruff.git", tag = "0.14.3" }


### PR DESCRIPTION
This allows a single wheel to be used for all compatible versions of
Python, rather than needing a separate wheel for each major version.

Adapted from #65

Co-authored-by: Joren Hammudoglu <jhammudoglu@gmail.com>
