### PR TITLE
enable free-threading builds in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.14t"
           allow-prereleases: true
       - name: Build wheel
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,41 @@ jobs:
         with:
           name: wheel-${{ matrix.target.os }}-${{ matrix.target.arch }}
           path: dist
+  build-free-threaded:
+    name: build ${{ matrix.target.os }} ${{ matrix.target.arch }} free-threaded
+    runs-on: ${{ matrix.target.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: macos-latest
+            arch: x86_64
+          - os: macos-latest
+            arch: aarch64
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: x64
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.14t
+          allow-prereleases: true
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target.arch }}
+          args: --release --out dist --interpreter '3.14t'
+          sccache: "true"
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v5
+        with:
+          name: wheel-${{ matrix.target.os }}-${{ matrix.target.arch }}-free-threaded
+          path: dist
 
   lint:
     name: lint
@@ -89,7 +124,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
     steps:
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,48 +56,13 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target.arch }}
-          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.14'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.14 3.14t'
           sccache: "true"
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v5
         with:
           name: wheel-${{ matrix.target.os }}-${{ matrix.target.arch }}
-          path: dist
-  build-free-threaded:
-    name: build ${{ matrix.target.os }} ${{ matrix.target.arch }} free-threaded
-    runs-on: ${{ matrix.target.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - os: macos-latest
-            arch: x86_64
-          - os: macos-latest
-            arch: aarch64
-          - os: ubuntu-latest
-            arch: x86_64
-          - os: ubuntu-latest
-            arch: aarch64
-          - os: windows-latest
-            arch: x64
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-        with:
-          python-version: 3.14t
-          allow-prereleases: true
-      - name: Build wheel
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target.arch }}
-          args: --release --out dist --interpreter '3.14t'
-          sccache: "true"
-          manylinux: auto
-      - name: Upload wheels
-        uses: actions/upload-artifact@v5
-        with:
-          name: wheel-${{ matrix.target.os }}-${{ matrix.target.arch }}-free-threaded
           path: dist
 
   lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta",
 ]
 requires-python = ">=3.9"
 dependencies = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::pymodule;
 ///
 /// Experimental Python API for Ruff
-#[pymodule(name = "_rust")]
+#[pymodule(name = "_rust", gil_used = false)]
 mod ruff_api {
     use pyo3::prelude::*;
     use ruff_formatter::LineWidth;


### PR DESCRIPTION
### Description

`ruff-api` is implemented with Rust extensions. This means, in order to support free-threaded
Python, we must build wheels that support FT Python explicitly. This PR attempts to cajole CI into
building those wheels, then rely on Publish Action to publish directly to PyPI.

This is created using [this guide](https://py-free-threading.github.io/ci/).

Fixes: #87
